### PR TITLE
Add Authorization callback URL to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd i-got-issues
 bundle
 ```
 
-Now got to https://github.com/settings/applications and register a new application, you'll need the *Client ID* and *Client Secret*.
+Now got to https://github.com/settings/applications and register a new application. You'll need the *Client ID* and *Client Secret*, if you run the server locally the *Authorization callback URL* is http://127.0.0.1:3000/auth/github/callback.
 
 Create a `.env` file in the root of the project and enter the following details filling in with the values you just copied after registering a new application:
 


### PR DESCRIPTION
I was just trying to run `i-got-issues` locally but I didn't know what to fill in as "Authorization callback URL". I looked it up in the `routes.rb`. This PR makes it easier for other users to get the project up and running.
