### PR TITLE
Fix access integration tests

### DIFF
--- a/test/integration/access_test.rb
+++ b/test/integration/access_test.rb
@@ -1,3 +1,5 @@
+require 'test_helper'
+
 class AccessTest < Capybara::Rails::TestCase
   test "unauthenticated user can access login" do
     visit "/"


### PR DESCRIPTION
Just added missing `require 'test_helper'` to `test/integration/access_test.rb`.